### PR TITLE
Revamp layout and add documentation page

### DIFF
--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { modulo } from './math';
 
 describe('modulo', () => {
-    it('handles negative dividend', () => {
-        expect(modulo(-1.5, 1)).toBeCloseTo(0.5);
-    });
-    it('handles negative divisor', () => {
-        expect(modulo(5, -2)).toBe(1);
-    });
+	it('handles negative dividend', () => {
+		expect(modulo(-1.5, 1)).toBeCloseTo(0.5);
+	});
+	it('handles negative divisor', () => {
+		expect(modulo(5, -2)).toBe(1);
+	});
 });

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -1,6 +1,6 @@
 export function modulo(n: number, m: number): number {
-    if (m === 0) return NaN;
-    const mod = Math.abs(m);
-    // handle negative numbers and divisors
-    return ((n % mod) + mod) % mod;
+	if (m === 0) return NaN;
+	const mod = Math.abs(m);
+	// handle negative numbers and divisors
+	return ((n % mod) + mod) % mod;
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,53 +5,18 @@
 	let { children } = $props();
 </script>
 
-<div class="app">
+<div class="flex min-h-screen flex-col">
 	<Header />
-
-	<main>
+	<main class="container mx-auto flex-1 p-8">
 		{@render children()}
 	</main>
-
-	<footer>
+	<footer class="bg-gray-100 py-6 text-center text-sm text-gray-600">
 		<p>
-			visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to learn about SvelteKit
+			<span>visit </span>
+			<a href="https://svelte.dev/docs/kit" class="font-semibold text-orange-600 hover:underline"
+				>svelte.dev/docs/kit</a
+			>
+			<span> to learn about SvelteKit</span>
 		</p>
 	</footer>
 </div>
-
-<style>
-	.app {
-		display: flex;
-		flex-direction: column;
-		min-height: 100vh;
-	}
-
-	main {
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		padding: 1rem;
-		width: 100%;
-		max-width: 64rem;
-		margin: 0 auto;
-		box-sizing: border-box;
-	}
-
-	footer {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		align-items: center;
-		padding: 12px;
-	}
-
-	footer a {
-		font-weight: bold;
-	}
-
-	@media (min-width: 480px) {
-		footer {
-			padding: 12px 0;
-		}
-	}
-</style>

--- a/src/routes/Counter.svelte
+++ b/src/routes/Counter.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-        import { Spring } from 'svelte/motion';
-        import { modulo } from '$lib/math';
+	import { Spring } from 'svelte/motion';
+	import { modulo } from '$lib/math';
 
-        const count = new Spring(0);
-        const offset = $derived(modulo(count.current, 1));
+	const count = new Spring(0);
+	const offset = $derived(modulo(count.current, 1));
 </script>
 
 <div class="counter">

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -1,129 +1,53 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import logo from '$lib/images/svelte-logo.svg';
-	import github from '$lib/images/github.svg';
 </script>
 
-<header>
-	<div class="corner">
-		<a href="https://svelte.dev/docs/kit">
-			<img src={logo} alt="SvelteKit" />
-		</a>
-	</div>
-
-	<nav>
-		<svg viewBox="0 0 2 3" aria-hidden="true">
-			<path d="M0,0 L1,2 C1.5,3 1.5,3 2,3 L2,0 Z" />
-		</svg>
-		<ul>
-			<li aria-current={page.url.pathname === '/' ? 'page' : undefined}>
-				<a href="/">Home</a>
-			</li>
-			<li aria-current={page.url.pathname === '/about' ? 'page' : undefined}>
-				<a href="/about">About</a>
-			</li>
-			<li aria-current={page.url.pathname.startsWith('/sverdle') ? 'page' : undefined}>
-				<a href="/sverdle">Sverdle</a>
-			</li>
-		</ul>
-		<svg viewBox="0 0 2 3" aria-hidden="true">
-			<path d="M0,0 L0,3 C0.5,3 0.5,3 1,2 L2,0 Z" />
-		</svg>
-	</nav>
-
-	<div class="corner">
-		<a href="https://github.com/sveltejs/kit">
-			<img src={github} alt="GitHub" />
-		</a>
+<header class="bg-white shadow">
+	<div class="container mx-auto flex items-center justify-between p-4">
+		<a href="/" class="text-xl font-bold text-orange-600">AnkiMCP</a>
+		<nav>
+			<ul class="flex space-x-4 text-sm">
+				<li>
+					<a
+						href="/"
+						class={page.url.pathname === '/'
+							? 'text-orange-600'
+							: 'text-gray-600 hover:text-orange-600'}
+					>
+						Home
+					</a>
+				</li>
+				<li>
+					<a
+						href="/docs"
+						class={page.url.pathname.startsWith('/docs')
+							? 'text-orange-600'
+							: 'text-gray-600 hover:text-orange-600'}
+					>
+						Docs
+					</a>
+				</li>
+				<li>
+					<a
+						href="/about"
+						class={page.url.pathname === '/about'
+							? 'text-orange-600'
+							: 'text-gray-600 hover:text-orange-600'}
+					>
+						About
+					</a>
+				</li>
+				<li>
+					<a
+						href="/sverdle"
+						class={page.url.pathname.startsWith('/sverdle')
+							? 'text-orange-600'
+							: 'text-gray-600 hover:text-orange-600'}
+					>
+						Sverdle
+					</a>
+				</li>
+			</ul>
+		</nav>
 	</div>
 </header>
-
-<style>
-	header {
-		display: flex;
-		justify-content: space-between;
-	}
-
-	.corner {
-		width: 3em;
-		height: 3em;
-	}
-
-	.corner a {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 100%;
-		height: 100%;
-	}
-
-	.corner img {
-		width: 2em;
-		height: 2em;
-		object-fit: contain;
-	}
-
-	nav {
-		display: flex;
-		justify-content: center;
-		--background: rgba(255, 255, 255, 0.7);
-	}
-
-	svg {
-		width: 2em;
-		height: 3em;
-		display: block;
-	}
-
-	path {
-		fill: var(--background);
-	}
-
-	ul {
-		position: relative;
-		padding: 0;
-		margin: 0;
-		height: 3em;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		list-style: none;
-		background: var(--background);
-		background-size: contain;
-	}
-
-	li {
-		position: relative;
-		height: 100%;
-	}
-
-	li[aria-current='page']::before {
-		--size: 6px;
-		content: '';
-		width: 0;
-		height: 0;
-		position: absolute;
-		top: 0;
-		left: calc(50% - var(--size));
-		border: var(--size) solid transparent;
-		border-top: var(--size) solid var(--color-theme-1);
-	}
-
-	nav a {
-		display: flex;
-		height: 100%;
-		align-items: center;
-		padding: 0 0.5rem;
-		color: var(--color-text);
-		font-weight: 700;
-		font-size: 0.8rem;
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		text-decoration: none;
-		transition: color 0.2s linear;
-	}
-
-	a:hover {
-		color: var(--color-theme-1);
-	}
-</style>

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -1,0 +1,29 @@
+<svelte:head>
+	<title>Documentation</title>
+	<meta name="description" content="Project documentation" />
+</svelte:head>
+
+<div class="prose mx-auto max-w-4xl p-8">
+	<h1>Documentation</h1>
+	<p>
+		Welcome to the AnkiMCP documentation. This guide will help you get started and explain the core
+		concepts.
+	</p>
+
+	<h2>Getting Started</h2>
+	<p>Install dependencies and run the development server:</p>
+	<pre><code
+			>npm install
+npm run dev</code
+		></pre>
+
+	<h2>Features</h2>
+	<ul>
+		<li>Modern SvelteKit application</li>
+		<li>Tailwind CSS for styling</li>
+		<li>TypeScript support</li>
+	</ul>
+
+	<h2>Next Steps</h2>
+	<p>Modify this page to include details about your project and add more sections as needed.</p>
+</div>

--- a/src/routes/docs/page.svelte.test.ts
+++ b/src/routes/docs/page.svelte.test.ts
@@ -1,0 +1,12 @@
+import { page } from '@vitest/browser/context';
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import Page from './+page.svelte';
+
+describe('/docs/+page.svelte', () => {
+	it('renders documentation heading', async () => {
+		render(Page);
+		const heading = page.getByRole('heading', { level: 1, name: /documentation/i });
+		await expect.element(heading).toBeInTheDocument();
+	});
+});

--- a/src/routes/sverdle/+page.svelte
+++ b/src/routes/sverdle/+page.svelte
@@ -58,9 +58,7 @@
 	 */
 	function update(event: MouseEvent) {
 		event.preventDefault();
-		const key = (event.target as HTMLButtonElement).getAttribute(
-			'data-key'
-		);
+		const key = (event.target as HTMLButtonElement).getAttribute('data-key');
 
 		if (key === 'backspace') {
 			currentGuess = currentGuess.slice(0, -1);


### PR DESCRIPTION
## Summary
- overhaul header and layout with Tailwind-based styling
- add dedicated `/docs` page with structured sections and prose styling
- include browser test for docs page and format codebase

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1187/chrome-linux/chrome)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ad23f6526c832ba2744c14e7bc633a